### PR TITLE
Add suggested prompts to home

### DIFF
--- a/app/Data/QuestionPlaceholder.php
+++ b/app/Data/QuestionPlaceholder.php
@@ -6,51 +6,36 @@ namespace App\Data;
 final class QuestionPlaceholder
 {
     public const SAMPLE_QUESTIONS = [
-        // Transaction-focused
-        'How many inputs and outputs are there?',
-        'What is the transaction fee?',
-        'What is the fee rate (sat/vB)?',
-        'Is this transaction using Taproot?',
-        'Is this a SegWit transaction?',
-        'What is the total value transferred?',
-        'What is the largest output value?',
-        'Are any outputs non-standard?',
-        'Are any of the addresses multisig?',
-        'Is this a coinbase transaction?',
-        'Was the fee considered high at the time?',
-        'What type of script does this transaction use?',
-        'What’s the likely purpose of this transaction?',
-        'Is this part of a CoinJoin?',
-        'Is this a self-transfer between wallets?',
-        'Does this transaction look like a batch payment?',
-        'Is this transaction economically relevant?',
-        'How old are the inputs in this transaction?',
-
-        // Block-focused
-        'Which mining pool mined this block?',
-        'How many transactions are in this block?',
-        'What is the total block reward?',
-        'What is the size of this block?',
-        'How long did it take to mine this block?',
-        'Are there any large transactions in this block?',
-        'Are there any Ordinals or inscriptions here?',
-        'What was the difficulty for this block?',
-        'Was this block mined quickly or slowly?',
-        'What is the average fee per transaction in this block?',
-        'Are there any unusual patterns in this block?',
-        'How much total value was transferred in this block?',
-
-        // General & Creative
-        'Explain this block in simple terms.',
-        'Is there anything interesting or unusual about this transaction?',
-        'Write a short explanation for beginners.',
-        'What stands out in this block’s activity?',
-        'Could this transaction be related to an exchange?',
-        'Is this a common pattern seen in Bitcoin usage?',
+        'transaction' => [
+            "What is the fee and fee rate?",
+            "Is this a CoinJoin or a batch transaction?",
+            "Does it use Taproot or SegWit?",
+            "Is it a self-transfer between wallets?",
+        ],
+        'block' => [
+            "Which pool mined this block?",
+            "How many transactions are inside?",
+            "How big is this block and how fast was it mined?",
+            "Are there any Ordinals or inscriptions?",
+        ],
+        'both' => [
+            "Explain this like I'm five.",
+            "What's unusual or interesting here?",
+            "Could this be linked to an exchange or service?",
+            "Write a short, simple summary.",
+        ],
     ];
 
     public static function rand(): string
     {
-        return self::SAMPLE_QUESTIONS[array_rand(self::SAMPLE_QUESTIONS)];
+        return collect(self::SAMPLE_QUESTIONS)->flatten()->random();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function groupedPrompts(): array
+    {
+        return self::SAMPLE_QUESTIONS;
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -28,6 +28,7 @@ final readonly class HomeController
     {
         return view('home', [
             'questionPlaceholder' => QuestionPlaceholder::rand(),
+            'suggestedPromptsGrouped' => QuestionPlaceholder::groupedPrompts(),
             'maxBitcoinBlockHeight' => $this->heightProvider->getMaxPossibleBlockHeight(),
         ]);
     }

--- a/resources/views/partials/form-fields.blade.php
+++ b/resources/views/partials/form-fields.blade.php
@@ -147,6 +147,41 @@
                         @enderror
                     </div>
 
+                    {{-- Suggested Prompts --}}
+                    <div x-data="{ promptType: null }"
+                         x-init="$watch('input', value => {
+        if (/^[a-fA-F0-9]{64}$/.test(value)) {
+            promptType = 'transaction';
+        } else if (/^\d+$/.test(value)) {
+            promptType = 'block';
+        } else {
+            promptType = null;
+        }
+     })"
+                         class="mt-3"
+                    >
+                        <template x-if="promptType">
+                            <div>
+                                <p class="text-sm font-medium text-gray-800 dark:text-gray-200 mb-1">
+                                    Suggested Questions
+                                </p>
+                                <div class="flex flex-wrap gap-2">
+                                    @foreach ($suggestedPromptsGrouped as $type => $questions)
+                                        <template x-if="promptType === '{{ $type }}' || '{{ $type }}' === 'both'">
+                                            <template x-for="prompt in @js($questions)" :key="prompt">
+                                                <button type="button"
+                                                        class="px-3 py-1 rounded-full text-sm bg-gray-100 hover:bg-orange-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-orange-400 dark:hover:text-gray-900 transition cursor-pointer"
+                                                        @click="document.getElementById('question').value = prompt">
+                                                    <span x-text="prompt"></span>
+                                                </button>
+                                            </template>
+                                        </template>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+
                     {{-- Refresh checkbox --}}
                     <div class="flex items-start gap-3">
                         <input


### PR DESCRIPTION
## 📚 Description

https://github.com/Chemaclass/satscribe/issues/4

Add a row of clickable prompts below the question field (e.g., “What’s weird about this block?”), which auto-fills the prompt input.

## 🔖 Changes

- Group `QuestionPlaceholder` for block, tx and both
- Display them on the home page depending on the user's input

<img width="758" alt="Screenshot 2025-05-01 at 16 18 32" src="https://github.com/user-attachments/assets/bd1fef94-bb72-4a69-b0dc-2ed18ccd3781" />


