### PR TITLE
Add block hash validation

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -166,11 +166,12 @@ function searchInputValidator(initial = '') {
 
         validate() {
             const trimmed = this.input.trim();
-            this.isHex64 = /^[a-fA-F0-9]{64}$/.test(trimmed);
             const height = parseInt(trimmed, 10);
-            this.isBlockHeight = /^\d+$/.test(trimmed) && height <= {{ $maxBitcoinBlockHeight ?? 100_000_000 }};
+
+            this.isHex64 = /^[a-fA-F0-9]{64}$/.test(trimmed);
+            this.isBlockHeight = /^\d+$/.test(trimmed) && height <= {{ $maxBitcoinBlockHeight ?? 10_000_000 }};
             this.isBlockHash = this.isHex64 && trimmed.startsWith('00000000');
-            this.valid = this.isBlockHeight || this.isBlockHash || (this.isHex64 && !this.isBlockHash);
+            this.valid = this.isHex64 || this.isBlockHeight || this.isBlockHash;
         }
     };
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -95,6 +95,7 @@ function searchInputValidator(initial = '') {
         valid: false,
         isHex64: false,
         isBlockHeight: false,
+        isBlockHash: false,
         isSubmitting: false,
 
         async submitForm(form) {
@@ -106,7 +107,7 @@ function searchInputValidator(initial = '') {
             try {
                 const formData = new FormData(form);
 
-                const { data } = await axios.post(form.action, formData, {
+                const {data} = await axios.post(form.action, formData, {
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
@@ -150,8 +151,9 @@ function searchInputValidator(initial = '') {
         },
 
         get helperText() {
-            if (!this.input.trim()) return 'Enter a valid TXID (64 hex chars) or block height (number).';
-            if (!this.valid) return 'Invalid format. Must be a TXID or block height.';
+            if (!this.input.trim()) return 'Enter a valid TXID (64 hex chars), block height (number), or block hash.';
+            if (!this.valid) return 'Invalid format. Must be a TXID, block height, or block hash.';
+            if (this.isBlockHash) return 'Valid block hash found.';
             if (this.isHex64) return 'Valid TXID (64 hex chars) found.';
             if (this.isBlockHeight) return 'Valid block height (number) found.';
             return '';
@@ -167,7 +169,8 @@ function searchInputValidator(initial = '') {
             this.isHex64 = /^[a-fA-F0-9]{64}$/.test(trimmed);
             const height = parseInt(trimmed, 10);
             this.isBlockHeight = /^\d+$/.test(trimmed) && height <= {{ $maxBitcoinBlockHeight ?? 100_000_000 }};
-            this.valid = this.isHex64 || this.isBlockHeight;
+            this.isBlockHash = this.isHex64 && trimmed.startsWith('00000000');
+            this.valid = this.isBlockHeight || this.isBlockHash || (this.isHex64 && !this.isBlockHash);
         }
     };
 }


### PR DESCRIPTION
## 📚 Description

closes https://github.com/Chemaclass/chemaclass.com/issues/32

## 🔖 Changes

- Add block hash validation on `searchInputValidator`


## 🖼️ Demo

### Block hash

<img width="719" alt="Screenshot 2025-05-03 at 11 28 31" src="https://github.com/user-attachments/assets/f3ce34ae-c296-4950-8d4b-13c43901827b" />

### Block height

<img width="799" alt="Screenshot 2025-05-03 at 11 28 43" src="https://github.com/user-attachments/assets/5426b159-137b-4dc7-805c-25ea5bf2fe23" />

### Tx hash

<img width="786" alt="Screenshot 2025-05-03 at 11 28 17" src="https://github.com/user-attachments/assets/bd8b2f6a-2fbe-49ac-916b-06ffc83609cd" />

### Invalid hash

<img width="794" alt="Screenshot 2025-05-03 at 11 29 56" src="https://github.com/user-attachments/assets/87b60737-f3c2-4da9-b68e-0ec7a84e5a90" />


