### PR TITLE
Implement BTC price currency toggle

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -118,6 +118,8 @@ final class AppServiceProvider extends ServiceProvider
         Paginator::useTailwind();
 
         View::share('cronitorClientKey', config('app.cronitorClientKey'));
-        View::share('btcPriceUsd', app(PriceService::class)->getCurrentBtcPriceUsd());;
+        $priceService = app(PriceService::class);
+        View::share('btcPriceUsd', $priceService->getCurrentBtcPriceUsd());
+        View::share('btcPriceEur', $priceService->getCurrentBtcPriceEur());
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -22,6 +22,7 @@ import {
     Scissors,
     Laptop,
     Lock,
+    ExternalLink,
 } from 'lucide';
 
 window.Alpine = Alpine;
@@ -48,6 +49,7 @@ const usedIcons = {
     Scissors,
     Laptop,
     Lock,
+    ExternalLink,
 };
 
 createIcons({icons: usedIcons});

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -47,13 +47,25 @@
         </button>
 
         @if(!empty($btcPriceUsd))
-            <a href="https://coinmarketcap.com/currencies/bitcoin/"
-               target="_blank"
-               rel="noopener"
-               class="nav-link hidden sm:inline-flex items-center gap-1 px-3 py-1 text-sm whitespace-nowrap"
+            <div
+                class="nav-link hidden sm:inline-flex items-center gap-1 px-3 py-1 text-sm whitespace-nowrap"
+                x-data="{ currency: 'usd' }"
             >
-                <span>${{ number_format($btcPriceUsd, 0) }}</span>
-            </a>
+                <span
+                    class="cursor-pointer"
+                    @click="currency = currency === 'usd' ? 'eur' : 'usd'"
+                >
+                    <span x-show="currency === 'usd'" x-cloak>
+                        ${{ number_format($btcPriceUsd, 0) }}
+                    </span>
+                    <span x-show="currency === 'eur'" x-cloak>
+                        &euro;{{ number_format($btcPriceEur, 0) }}
+                    </span>
+                </span>
+                <a href="https://coinmarketcap.com/currencies/bitcoin/" target="_blank" rel="noopener" class="flex items-center">
+                    <svg data-lucide="external-link" class="w-4 h-4"></svg>
+                </a>
+            </div>
         @endif
     </nav>
 </header>


### PR DESCRIPTION
## Summary
- fetch both USD and EUR BTC prices
- expose the two prices in the application service provider
- show price in the header with a toggle and external link
- load the new icon in the JS bundle

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: vite not found)*