### PR TITLE
Add cny and gbp prices

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -118,8 +118,11 @@ final class AppServiceProvider extends ServiceProvider
         Paginator::useTailwind();
 
         View::share('cronitorClientKey', config('app.cronitorClientKey'));
+
         $priceService = app(PriceService::class);
         View::share('btcPriceUsd', $priceService->getCurrentBtcPriceUsd());
         View::share('btcPriceEur', $priceService->getCurrentBtcPriceEur());
+        View::share('btcPriceCny', $priceService->getCurrentBtcPriceCny());
+        View::share('btcPriceGbp', $priceService->getCurrentBtcPriceGbp());
     }
 }

--- a/app/Services/PriceService.php
+++ b/app/Services/PriceService.php
@@ -33,16 +33,31 @@ final readonly class PriceService
         return $this->getPrices()['eur'];
     }
 
+    public function getCurrentBtcPriceCny(): float
+    {
+        return $this->getPrices()['cny'];
+    }
+
+    public function getCurrentBtcPriceGbp(): float
+    {
+        return $this->getPrices()['gbp'];
+    }
+
     private function getPrices(): array
     {
         if (!$this->enabled) {
-            return ['usd' => 0.0, 'eur' => 0.0];
+            return [
+                'usd' => 0.0,
+                'eur' => 0.0,
+                'cny' => 0.0,
+                'gbp' => 0.0,
+            ];
         }
 
         return $this->cache->remember(self::CACHE_KEY, now()->addMinutes(self::CACHE_TTL_MINUTES), function () {
             $response = $this->http->get(self::BASE_URL.'/v3/simple/price', [
                 'ids' => 'bitcoin',
-                'vs_currencies' => 'usd,eur',
+                'vs_currencies' => 'usd,eur,cny,gbp',
             ]);
 
             if (!$response->successful()) {
@@ -55,6 +70,8 @@ final readonly class PriceService
             return [
                 'usd' => (float) $response->json('bitcoin.usd'),
                 'eur' => (float) $response->json('bitcoin.eur'),
+                'cny' => (float) $response->json('bitcoin.cny'),
+                'gbp' => (float) $response->json('bitcoin.gbp'),
             ];
         });
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,6 @@
 import './bootstrap';
 import Alpine from 'alpinejs';
+import StorageClient from './storage-client';
 import {
     BadgeCheck,
     Bitcoin,
@@ -26,6 +27,7 @@ import {
 } from 'lucide';
 
 window.Alpine = Alpine;
+window.StorageClient = StorageClient;
 Alpine.start();
 
 const usedIcons = {

--- a/resources/js/storage-client.js
+++ b/resources/js/storage-client.js
@@ -1,0 +1,10 @@
+const StorageClient = {
+    getFiatCurrency() {
+        return localStorage.getItem('fiat_currency');
+    },
+    setFiatCurrency(currency) {
+        localStorage.setItem('fiat_currency', currency);
+    },
+};
+
+export default StorageClient;

--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -1,6 +1,8 @@
 @props([
     'btcPriceUsd' => null,
     'btcPriceEur' => null,
+    'btcPriceCny' => null,
+    'btcPriceGbp' => null,
 ])
 
 <header class="flex justify-between items-center px-4 py-3 border-gray-200 dark:border-gray-700">
@@ -23,14 +25,28 @@
         @if(!empty($btcPriceUsd))
             <div
                 class="nav-link hidden sm:inline-flex items-center gap-1 px-3 py-1 text-sm whitespace-nowrap"
-                x-data="{ currency: 'usd' }"
+                x-data="{
+                    currency: StorageClient.getFiatCurrency() || 'usd',
+                    toggle() {
+                        const order = ['usd', 'eur', 'cny', 'gbp'];
+                        const idx = order.indexOf(this.currency);
+                        this.currency = order[(idx + 1) % order.length];
+                        StorageClient.setFiatCurrency(this.currency);
+                    }
+                }"
             >
-                <span class="cursor-pointer" @click="currency = currency === 'usd' ? 'eur' : 'usd'">
+                <span class="cursor-pointer" @click="toggle()">
                     <span x-show="currency === 'usd'" x-cloak>
                         ${{ number_format($btcPriceUsd, 0) }}
                     </span>
                     <span x-show="currency === 'eur'" x-cloak>
                         &euro;{{ number_format($btcPriceEur, 0) }}
+                    </span>
+                    <span x-show="currency === 'cny'" x-cloak>
+                        &yen;{{ number_format($btcPriceCny, 0) }}
+                    </span>
+                    <span x-show="currency === 'gbp'" x-cloak>
+                        &pound;{{ number_format($btcPriceGbp, 0) }}
                     </span>
                 </span>
                 <a href="https://coinmarketcap.com/currencies/bitcoin/" target="_blank" rel="noopener" class="flex items-center">

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -28,16 +28,19 @@
     @stack('head')
 </head>
 <body class="min-h-screen flex flex-col transition-colors duration-300">
-<x-layout.header :btc-price-usd="$btcPriceUsd" :btc-price-eur="$btcPriceEur" />
+    <x-layout.header
+        :btc-price-usd="$btcPriceUsd"
+        :btc-price-eur="$btcPriceEur"
+        :btc-price-cny="$btcPriceCny"
+        :btc-price-gbp="$btcPriceGbp"
+    />
 
-<main class="flex-grow">
-    @yield('content')
-</main>
+    <main class="flex-grow">
+        @yield('content')
+    </main>
 
-<x-layout.footer />
-
-<x-layout.scroll-to-top />
-
-@stack('scripts')
+    <x-layout.footer />
+    <x-layout.scroll-to-top />
+    @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
## 🔖 Changes

- Add cny and gpb prices to nav-bar toggle
- Save selected fiat_currency via StorageClient

https://github.com/user-attachments/assets/df559a07-7937-40a5-96bc-121660af0f73

