### PR TITLE
Implement localized FAQ and language switcher

### DIFF
--- a/app/Console/Commands/ImportFaqs.php
+++ b/app/Console/Commands/ImportFaqs.php
@@ -75,12 +75,14 @@ final class ImportFaqs extends Command
     private function processRow(array $row, Carbon $now, array &$rows): void
     {
         $question = $row['question'] ?? '';
-        $existing = $this->faqRepository->findByQuestion($question);
+        $lang = $row['lang'] ?? 'en';
+        $existing = $this->faqRepository->findByQuestion($question, $lang);
 
         $data = [
             'answer_beginner' => $row['answer_beginner'] ?? '',
             'answer_advance' => $row['answer_advance'] ?? '',
             'answer_tldr' => $row['answer_tldr'] ?? '',
+            'lang' => $lang,
             'categories' => $row['categories'] ?? '',
             'highlight' => filter_var($row['highlight'] ?? false, FILTER_VALIDATE_BOOLEAN),
             'priority' => (int) ($row['priority'] ?? 0),

--- a/app/Models/Faq.php
+++ b/app/Models/Faq.php
@@ -12,6 +12,7 @@ final class Faq extends Model
         'answer_beginner',
         'answer_advance',
         'answer_tldr',
+        'lang',
         'categories',
         'highlight',
         'priority',

--- a/app/Repositories/FaqRepository.php
+++ b/app/Repositories/FaqRepository.php
@@ -10,9 +10,15 @@ use App\Repositories\FaqRepositoryInterface;
 
 final class FaqRepository implements FaqRepositoryInterface
 {
-    public function findByQuestion(string $question): ?object
+    public function findByQuestion(string $question, ?string $lang = null): ?object
     {
-        return DB::table('faqs')->where('question', $question)->first();
+        $query = DB::table('faqs')->where('question', $question);
+
+        if ($lang !== null) {
+            $query->where('lang', $lang);
+        }
+
+        return $query->first();
     }
 
     public function update(int $id, array $data): void
@@ -27,12 +33,14 @@ final class FaqRepository implements FaqRepositoryInterface
 
     public function getCollectionBySearch(string $search): Collection
     {
-        $query = Faq::query();
+        $query = Faq::query()->where('lang', app()->getLocale());
 
         if ($search !== '' && $search !== '0') {
             $query->where(function ($q) use ($search): void {
-                $q->where('title', 'like', "%{$search}%")
-                    ->orWhere('description', 'like', "%{$search}%");
+                $q->where('question', 'like', "%{$search}%")
+                    ->orWhere('answer_tldr', 'like', "%{$search}%")
+                    ->orWhere('answer_advance', 'like', "%{$search}%")
+                    ->orWhere('answer_beginner', 'like', "%{$search}%");
             });
         }
 

--- a/app/Repositories/FaqRepositoryInterface.php
+++ b/app/Repositories/FaqRepositoryInterface.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Collection;
 
 interface FaqRepositoryInterface
 {
-    public function findByQuestion(string $question): ?object;
+    public function findByQuestion(string $question, ?string $lang = null): ?object;
 
     public function update(int $id, array $data): void;
 

--- a/database/migrations/2025_07_01_000000_add_lang_to_faqs_table.php
+++ b/database/migrations/2025_07_01_000000_add_lang_to_faqs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('faqs', function (Blueprint $table): void {
+            $table->string('lang', 5)->default('en')->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('faqs', function (Blueprint $table): void {
+            $table->dropColumn('lang');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -83,7 +83,7 @@ function setupBlockchainToggle() {
 
     toggleBtn.addEventListener('click', () => {
         const collapsed = rawBlock.classList.toggle('collapsed');
-        toggleBtn.textContent = collapsed ? 'Show more' : 'Show less';
+        toggleBtn.textContent = collapsed ? window.i18n.showMore : window.i18n.showLess;
     });
 }
 
@@ -109,8 +109,8 @@ const toggleRawBlockVisibility = (button, rawBlock, visible) => {
     const fullSpan = button.querySelector('.full-label');
     const shortSpan = button.querySelector('.short-label');
 
-    if (fullSpan) fullSpan.textContent = visible ? 'Hide raw data' : 'Show raw data';
-    if (shortSpan) shortSpan.textContent = visible ? 'Hide' : 'Raw';
+    if (fullSpan) fullSpan.textContent = visible ? window.i18n.hideRawData : window.i18n.showRawData;
+    if (shortSpan) shortSpan.textContent = visible ? window.i18n.hide : window.i18n.raw;
 };
 
 const loadRawData = async (messageId) => {

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -43,6 +43,8 @@
     "Show raw data": "Rohdaten anzeigen",
     "Raw": "Roh",
     "Hide raw data": "Rohdaten verbergen",
+    "Show more": "Mehr anzeigen",
+    "Show less": "Weniger anzeigen",
     "Loading...": "Wird geladen...",
     "Invoice Copied!": "Rechnung kopiert!",
     "Copy": "Kopieren",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -43,6 +43,8 @@
     "Show raw data": "Show raw data",
     "Raw": "Raw",
     "Hide raw data": "Hide raw data",
+    "Show more": "Show more",
+    "Show less": "Show less",
     "Loading...": "Loading...",
     "Invoice Copied!": "Invoice Copied!",
     "Copy": "Copy",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -43,6 +43,8 @@
     "Show raw data": "Mostrar datos sin procesar",
     "Raw": "Sin procesar",
     "Hide raw data": "Ocultar datos sin procesar",
+    "Show more": "Mostrar más",
+    "Show less": "Mostrar menos",
     "Loading...": "Cargando...",
     "Invoice Copied!": "Factura copiada",
     "Copy": "Copiar",

--- a/resources/views/components/layout/footer.blade.php
+++ b/resources/views/components/layout/footer.blade.php
@@ -11,5 +11,11 @@
             <svg data-lucide="github" class="w-4 h-4"></svg>
             {{ __('GitHub') }}
         </a>
+        <span class="hidden sm:inline">•</span>
+        <select class="nav-link" onchange="const p=new URLSearchParams(window.location.search);p.set('lang', this.value);window.location.search=p.toString();">
+            <option value="en" @selected(app()->getLocale()==='en')>EN</option>
+            <option value="de" @selected(app()->getLocale()==='de')>DE</option>
+            <option value="es" @selected(app()->getLocale()==='es')>ES</option>
+        </select>
     </div>
 </footer>

--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -22,11 +22,6 @@
             <span class="link-text" x-text="dark ? '{{ __('Light') }}' : '{{ __('Dark') }}'"></span>
         </button>
 
-        <select class="nav-link ml-2" onchange="const p=new URLSearchParams(window.location.search);p.set('lang', this.value);window.location.search=p.toString();">
-            <option value="en" @selected(app()->getLocale()==='en')>EN</option>
-            <option value="de" @selected(app()->getLocale()==='de')>DE</option>
-            <option value="es" @selected(app()->getLocale()==='es')>ES</option>
-        </select>
 
         @if(!empty($btcPriceUsd))
             <div

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -25,6 +25,16 @@
         cronitor('config', { clientKey: '{{$cronitorClientKey}}' });
     </script>
     @endif
+    <script>
+        window.i18n = {
+            showMore: "{{ __('Show more') }}",
+            showLess: "{{ __('Show less') }}",
+            showRawData: "{{ __('Show raw data') }}",
+            hideRawData: "{{ __('Hide raw data') }}",
+            hide: "{{ __('Hide') }}",
+            raw: "{{ __('Raw') }}"
+        };
+    </script>
     @stack('head')
 </head>
 <body class="min-h-screen flex flex-col transition-colors duration-300">


### PR DESCRIPTION
## Summary
- move language select from header to footer
- localize JS toggled labels via `window.i18n`
- store FAQ language in database and filter by locale
- update ImportFaqs command for lang column
- add translations for "Show more" and "Show less"

## Testing
- `composer install` *(fails: `composer` not found)*
- `npm test` *(fails: Missing script)*